### PR TITLE
Add base visibility style to stop layout shift

### DIFF
--- a/scss/shared/_base.scss
+++ b/scss/shared/_base.scss
@@ -68,6 +68,10 @@ small {
   display: none;
 }
 
+.visibility-hidden {
+  visibility: hidden;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-weight: 600;
   color: rgb(var(--zn-text-heading));


### PR DESCRIPTION
This class can be used in place of a hidden toggle to stop layout shift.

This should probably be used in conjunction with `aria-hidden` on elements.