### PR TITLE
Add free-text entry to zn-select (and zn-inline-edit)

### DIFF
--- a/docs/pages/components/inline-edit.md
+++ b/docs/pages/components/inline-edit.md
@@ -151,6 +151,26 @@ Add the `search` attribute to enable filtering on select inputs. Users can type 
 </div>
 ```
 
+### Free Text Select
+
+Add the `free-text` attribute to let users enter values that aren't in the options list (see [`zn-select`](/components/select#free-text-entry)). `free-text` implies a select input, so you don't need `input-type="select"`. Combine it with `multiple` for a tag-style editor.
+
+```html:preview
+<div class="form-spacing">
+  <zn-inline-edit name="status" value="active" free-text>
+    <zn-option value="active">Active</zn-option>
+    <zn-option value="inactive">Inactive</zn-option>
+    <zn-option value="pending">Pending</zn-option>
+  </zn-inline-edit>
+
+  <zn-inline-edit name="tags" free-text multiple value="urgent backend">
+    <zn-option value="urgent">Urgent</zn-option>
+    <zn-option value="backend">Backend</zn-option>
+    <zn-option value="frontend">Frontend</zn-option>
+  </zn-inline-edit>
+</div>
+```
+
 ### Data Select with Provider
 
 Use the `provider` attribute to integrate with data select providers like countries, currencies, or colors.

--- a/docs/pages/components/select.md
+++ b/docs/pages/components/select.md
@@ -185,6 +185,31 @@ Combine `search` with `multiple` to allow users to search and select multiple op
 </zn-select>
 ```
 
+### Free Text Entry
+
+Use the `free-text` attribute to let users enter values that aren't in the options list. `free-text` implies the editable, filtering input behavior of `search`, so users can both filter existing options and add their own. When the typed text doesn't match an existing option, an **Add "…"** row appears at the top of the listbox; committing it (by pressing <kbd>Enter</kbd>, clicking the Add row, or blurring the field) adds the value as a selection. A committed value becomes both the option's value and its label.
+
+If the typed text exactly matches an existing option (by label or value, case-insensitive), the Add row is suppressed and the existing option is selected instead — so no duplicates are created.
+
+```html:preview
+<zn-select label="Add tags" free-text placeholder="Type a tag and press Enter">
+  <zn-option value="bug">Bug</zn-option>
+  <zn-option value="feature">Feature</zn-option>
+  <zn-option value="chore">Chore</zn-option>
+</zn-select>
+```
+
+### Free Text with Multiple Selection
+
+Combine `free-text` with `multiple` to build a tag-style input. Each committed value is added as a tag and the input stays open so users can keep entering values. Removing a tag whose value was entered as free text deletes it entirely.
+
+```html:preview
+<zn-select label="Recipients" free-text multiple clearable placeholder="Add email addresses...">
+  <zn-option value="support@example.com">support@example.com</zn-option>
+  <zn-option value="sales@example.com">sales@example.com</zn-option>
+</zn-select>
+```
+
 ### Remote Search
 
 When `search` and `data-uri` are used together, typing in the select sends debounced requests to the server instead of filtering locally. The search term is appended as a query parameter (default `q`). Use `search-param` to customise the parameter name, `search-debounce` to control the delay, and `max-results` to cap displayed results.

--- a/src/components/inline-edit/inline-edit.component.ts
+++ b/src/components/inline-edit/inline-edit.component.ts
@@ -108,6 +108,12 @@ export default class ZnInlineEdit extends ZincElement implements ZincFormControl
   /** Enables search/filtering on select inputs. */
   @property({ type: Boolean }) search: boolean;
 
+  /**
+   * Allows entering values that aren't in the options list on select inputs ("free text"). Setting this implies
+   * `input-type="select"` (unless a data `provider` is used) and forwards the behavior to the inner `<zn-select>`.
+   */
+  @property({ type: Boolean, attribute: 'free-text' }) freeText: boolean;
+
   /** The input's help text. If you need to display HTML, use the `help-text` slot instead. **/
   @property({ attribute: 'help-text' }) helpText: string = '';
 
@@ -315,6 +321,11 @@ export default class ZnInlineEdit extends ZincElement implements ZincFormControl
       this.inputType = 'data-select';
     }
 
+    // Free text is a select capability — imply a select input when it's set (unless a data provider is used)
+    if (this.freeText && !this.selectProvider) {
+      this.inputType = 'select';
+    }
+
     let input: HTMLTemplateResult;
     switch (this.inputType) {
       case 'select':
@@ -457,7 +468,8 @@ export default class ZnInlineEdit extends ZincElement implements ZincFormControl
                  multiple=${ifDefined(this.multiple)}
                  clearable=${ifDefined(this.isEditing ? this.clearable : undefined)}
                  ?search=${this.search}
-                 non-removable
+                 ?free-text=${this.freeText}
+                 ?non-removable=${!this.isEditing}
                  data-uri=${ifDefined(this.dataUri)}
                  context-data=${ifDefined(this.contextData)}
                  @zn-input="${this.handleInput}"

--- a/src/components/inline-edit/inline-edit.test.ts
+++ b/src/components/inline-edit/inline-edit.test.ts
@@ -309,6 +309,56 @@ describe('<zn-inline-edit>', () => {
     expect(formData.get('tags')).to.equal('');
   });
 
+  // -- Free text --
+
+  it('should pass free-text to the inner select', async () => {
+    const el = await fixture<ZnInlineEdit>(html`
+      <zn-inline-edit input-type="select" free-text>
+        <zn-option value="a">A</zn-option>
+      </zn-inline-edit>
+    `);
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector('zn-select') as ZnSelect;
+    expect(select).to.exist;
+    expect(select.freeText).to.be.true;
+  });
+
+  it('should render a free-text select when free-text is set without an input-type', async () => {
+    const el = await fixture<ZnInlineEdit>(html`
+      <zn-inline-edit free-text></zn-inline-edit>
+    `);
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector('zn-select') as ZnSelect;
+    expect(select, 'free-text should imply a select input').to.exist;
+    expect(select.freeText).to.be.true;
+  });
+
+  it('should make inner select tags removable only while editing', async () => {
+    const el = await fixture<ZnInlineEdit>(html`
+      <zn-inline-edit free-text multiple value="a">
+        <zn-option value="a">A</zn-option>
+      </zn-inline-edit>
+    `);
+    await el.updateComplete;
+
+    const select = el.shadowRoot?.querySelector('zn-select') as ZnSelect;
+    expect(select).to.exist;
+
+    // Display mode: tags are not removable (no X)
+    expect(select.nonRemovable).to.be.true;
+
+    // Enter edit mode
+    const editBtn = el.shadowRoot!.querySelector<HTMLElement>('.button--edit')!;
+    editBtn.dispatchEvent(new MouseEvent('click', {bubbles: true, composed: true}));
+    await el.updateComplete;
+    await select.updateComplete;
+
+    // Editing: tags become removable (X shows)
+    expect(select.nonRemovable).to.be.false;
+  });
+
   it('should flatten array to string when multiple is not set', async () => {
     const el = await fixture<ZnInlineEdit>(
       html`<zn-inline-edit value="hello"></zn-inline-edit>`

--- a/src/components/option/option.scss
+++ b/src/components/option/option.scss
@@ -30,11 +30,13 @@
 }
 
 
-.option--hover:not(.option--current):not(.option--disabled) {
-  background-color: var(--zn-color-primary-100);
-  color: var(--zn-input-color);
+/* Selected is the base highlight; hover/current below take priority over it. */
+.option--selected {
+  background-color: var(--zn-color-primary-200);
 }
 
+/* Mouse-hover and keyboard-current take priority over the selected background. */
+.option--hover:not(.option--disabled),
 .option--current,
 .option--current.option--disabled {
   background-color: var(--zn-color-primary-100);
@@ -67,10 +69,6 @@
 
 .option--selected .option__check {
   visibility: visible;
-}
-
-.option--selected {
-  background-color: var(--zn-color-primary-200);
 }
 
 .option__prefix,

--- a/src/components/option/option.test.ts
+++ b/src/components/option/option.test.ts
@@ -1,10 +1,40 @@
 import '../../../dist/zn.min.js';
 import { expect, fixture, html } from '@open-wc/testing';
+import type ZnOption from './option.component';
 
 describe('<zn-option>', () => {
   it('should render a component', async () => {
     const el = await fixture(html` <zn-option></zn-option> `);
 
     expect(el).to.exist;
+  });
+
+  it('prioritises the hover/current highlight over the selected background', async () => {
+    // Inject the palette so the computed colors resolve deterministically in the test environment.
+    const el = await fixture<ZnOption>(html`
+      <zn-option
+        value="a"
+        selected
+        style="--zn-color-primary-100: rgb(10, 20, 30); --zn-color-primary-200: rgb(40, 50, 60);">
+        A
+      </zn-option>
+    `);
+    await el.updateComplete;
+
+    const base = el.shadowRoot!.querySelector<HTMLElement>('.option')!;
+
+    // Selected only → the selected background
+    expect(getComputedStyle(base).backgroundColor).to.equal('rgb(40, 50, 60)');
+
+    // Keyboard-current + selected → the highlight must win over selected
+    el.current = true;
+    await el.updateComplete;
+    expect(getComputedStyle(base).backgroundColor, 'current should win over selected').to.equal('rgb(10, 20, 30)');
+
+    // Mouse-hover + selected → the highlight must win over selected
+    el.current = false;
+    el.hasHover = true;
+    await el.updateComplete;
+    expect(getComputedStyle(base).backgroundColor, 'hover should win over selected').to.equal('rgb(10, 20, 30)');
   });
 });

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -113,8 +113,9 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
   /** @internal - current search/filter text when search is enabled (lowercased for matching) */
   private _searchQuery = '';
 
-  /** @internal - raw display value of the search input (preserves case for the input field) */
-  private _searchDisplayValue = '';
+  /** @internal - raw display value of the search input (preserves case for the input field). Reactive so the
+   * free-text "Add" row re-renders on every keystroke, not just when the match/no-match state changes. */
+  @state() private _searchDisplayValue = '';
 
   /** @internal - whether the "no matching options" empty state is visible */
   @state() private _noResultsVisible = false;
@@ -274,6 +275,14 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
 
   /** Enables search/filter functionality. When enabled, the user can type into the select to filter the visible options. */
   @property({type: Boolean, reflect: true}) search = false;
+
+  /**
+   * Allows the user to enter values that are not in the options list ("free text"). Implies the editable,
+   * filtering input behavior of `search`. A typed value that doesn't match an existing option is committed
+   * by pressing Enter, clicking the "Add" row, or blurring the field, and becomes a selected option — a tag
+   * when `multiple` is enabled. The committed value is both the option's value and its label.
+   */
+  @property({type: Boolean, reflect: true, attribute: 'free-text'}) freeText = false;
 
   /** The select's label. If you need to display HTML, use the `label` slot instead. */
   @property() label = '';
@@ -477,6 +486,13 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       return;
     }
 
+    // Escape cancels uncommitted free-text rather than letting the close path commit it. Done here (before
+    // either the CloseWatcher or the branch below closes the dropdown) so it applies on every browser.
+    if (event.key === 'Escape' && this.open && this.freeText && this._searchDisplayValue.trim()) {
+      this.clearSearch();
+      this.displayInput.value = '';
+    }
+
     // Close when pressing escape
     if ((event.key === 'Escape' || event.key === 'Tab') && this.open && !this.closeWatcher) {
       event.preventDefault();
@@ -494,7 +510,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
 
     // Handle enter and space. When pressing space, we allow for type to select behaviors so if there's anything in the
     // buffer we _don't_ close it. When search is enabled, space should type into the input, not toggle.
-    if (event.key === 'Enter' || (event.key === ' ' && !this.search && this.typeToSelectString === '')) {
+    if (event.key === 'Enter' || (event.key === ' ' && !this._isTypeable && this.typeToSelectString === '')) {
       event.preventDefault();
       event.stopImmediatePropagation();
 
@@ -502,6 +518,14 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       if (!this.open) {
         this.show().then();
         return;
+      }
+
+      // Free-text: a highlighted real option wins; otherwise commit the typed value
+      if (this.freeText) {
+        const usableCurrent = this.currentOption && !this.currentOption.disabled && !this.currentOption.hidden;
+        if (!usableCurrent && this.commitFreeText()) {
+          return;
+        }
       }
 
       // If it is open, update the value based on the current selection and close it
@@ -514,7 +538,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
         }
 
         // Clear search after keyboard selection
-        if (this.search) {
+        if (this._isTypeable) {
           this.clearSearch();
           if (this.multiple) {
             this.displayInput.value = '';
@@ -530,8 +554,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
         if (!this.multiple) {
           this.hide().then();
           this.displayInput.focus({preventScroll: true});
-        } else if (this.search) {
-          // In multi-select + search, re-focus the search input after keyboard selection
+        } else if (this._isTypeable) {
+          // In multi-select + typeable, re-focus the search input after keyboard selection
           this.updateComplete.then(() => {
             this.displayInput.value = '';
             this.displayInput.focus({preventScroll: true});
@@ -544,7 +568,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
 
     // Navigate options
     if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
-      const navOptions = this.search ? this.getVisibleOptions() : this.getAllOptions();
+      const navOptions = this._isTypeable ? this.getVisibleOptions() : this.getAllOptions();
       const currentIndex = navOptions.indexOf(this.currentOption);
       let newIndex = Math.max(0, currentIndex);
 
@@ -577,8 +601,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       this.setCurrentOption(navOptions[newIndex]);
     }
 
-    // When search is enabled, let the input handle keystrokes natively (they go through handleSearchInput)
-    if (this.search) {
+    // When typeable, let the input handle keystrokes natively (they go through handleSearchInput)
+    if (this._isTypeable) {
       return;
     }
 
@@ -648,8 +672,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       return;
     }
 
-    // When search is enabled, clicking the input area should open (not toggle) so the user can type
-    if (this.search && this.open && !isExpandIcon) {
+    // When typeable, clicking the input area should open (not toggle) so the user can type
+    if (this._isTypeable && this.open && !isExpandIcon) {
       event.preventDefault();
       this.displayInput.focus({preventScroll: true});
       return;
@@ -679,7 +703,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     event.stopPropagation();
 
     if (this.value !== '') {
-      if (this.search) {
+      if (this._isTypeable) {
         this.clearSearch();
         this.displayInput.value = '';
       }
@@ -711,9 +735,14 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     return this.search && !!this.dataUri;
   }
 
+  /** Whether the display input is editable and filters options (search or free-text). */
+  private get _isTypeable() {
+    return this.search || this.freeText;
+  }
+
   /** Handles text input on the display input for search/filter mode */
   private handleSearchInput() {
-    if (!this.search) return;
+    if (!this._isTypeable) return;
 
     this._searchDisplayValue = this.displayInput.value;
     this._searchQuery = this._searchDisplayValue.toLowerCase();
@@ -825,8 +854,126 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     });
   }
 
+  /**
+   * Commits the current typed text as a selected value when `free-text` is enabled. A selected `<zn-option>`
+   * (value = label = trimmed text) is created in the light DOM so the value flows through the existing
+   * tag/value/selection machinery and appears as a deselectable row in the listbox. Returns `true` when
+   * something was committed, `false` when there was nothing to commit.
+   */
+  private commitFreeText(refocus = true): boolean {
+    if (!this.freeText) return false;
+
+    const text = (this.displayInput?.value ?? '').trim();
+    if (!text) return false;
+
+    this.valueHasChanged = true;
+
+    // If the text matches an existing option (label or value, case-insensitive), select it instead of
+    // creating a duplicate free-text option.
+    const lower = text.toLowerCase();
+    const existing = this.getAllOptions().find(
+      o => o.value.toLowerCase() === lower || o.getTextLabel().toLowerCase() === lower
+    );
+
+    const option = existing ?? this._createFreeTextOption(text);
+
+    if (this.multiple) {
+      // Add to the existing selection and keep the dropdown open for more entry
+      this.toggleOptionSelection(option, true);
+    } else {
+      this.setSelectedOptions(option);
+    }
+
+    this.clearSearch();
+
+    this.updateComplete.then(() => {
+      this.emit('zn-input');
+      this.emit('zn-change');
+    });
+
+    // When committed via blur/close, the dropdown is already closing and focus has left — don't fight it.
+    if (!refocus) {
+      return true;
+    }
+
+    if (this.multiple) {
+      // Clear the input so the user can type the next value
+      this.displayInput.value = '';
+      this.displayInput.focus({preventScroll: true});
+    } else {
+      this.hide().then();
+      this.displayInput.focus({preventScroll: true});
+    }
+
+    return true;
+  }
+
+  /**
+   * The trimmed pending text to offer as a free-text "Add" row, or `null` when no Add row should be shown
+   * (free-text disabled, dropdown closed, input empty, or the text exactly matches an existing option).
+   */
+  private get _freeTextAddValue(): string | null {
+    if (!this.freeText || !this.open) return null;
+
+    const text = this._searchDisplayValue.trim();
+    if (!text) return null;
+
+    const lower = text.toLowerCase();
+    const exact = this.getAllOptions().some(
+      o => o.value.toLowerCase() === lower || o.getTextLabel().toLowerCase() === lower
+    );
+
+    return exact ? null : text;
+  }
+
+  /** Commits the typed value when the "Add" row is pressed, keeping focus on the input. */
+  private handleAddOptionMouseDown(event: MouseEvent) {
+    // Keep focus on the input but DON'T commit here. Committing on mousedown would clear the search and
+    // collapse the listbox, so the following mouseup would land on (and select) whichever option shifted
+    // under the cursor. Instead the commit happens on mouseup in handleOptionClick.
+    event.preventDefault();
+  }
+
+  /**
+   * In free-text mode, creates a hidden `<zn-option>` for any value that has no matching option, so values
+   * set via the `value`/`defaultValue` attribute (e.g. previously-saved custom entries) render as tags or
+   * the display value on load. No-op when free-text is disabled.
+   */
+  private _materialiseFreeTextValues(values: string[]) {
+    if (!this.freeText) return;
+
+    const existingValues = new Set(this.getAllOptions().map(o => o.value));
+    values.forEach(value => {
+      if (value === '' || existingValues.has(value)) return;
+      this._createFreeTextOption(value);
+      existingValues.add(value);
+    });
+  }
+
+  /**
+   * Creates a free-text-marked `<zn-option>` in the light DOM (value = label) and returns it. The option is
+   * a normal, visible, selectable row so the user can deselect a custom value from the dropdown like any
+   * other option; the `data-free-text` marker lets us drop it from the DOM once it's no longer selected.
+   */
+  private _createFreeTextOption(value: string): ZnOption {
+    const option = document.createElement('zn-option') as ZnOption;
+    option.value = value;
+    option.textContent = value;
+    option.setAttribute('data-free-text', '');
+    this.appendChild(option);
+    return option;
+  }
+
   private handleOptionClick(event: MouseEvent) {
     const target = event.target as HTMLElement;
+
+    // The free-text "Add" row lives in the listbox and commits on this same mouseup, so it can never
+    // also trigger an option selection.
+    if (target.closest('.select__add-option')) {
+      this.commitFreeText();
+      return;
+    }
+
     const option = target.closest('zn-option');
     const oldValue = this.value;
 
@@ -841,8 +988,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
         this.setSelectedOptions(option);
       }
 
-      // Clear search after selection when in search mode
-      if (this.search) {
+      // Clear search after selection when in search/free-text mode
+      if (this._isTypeable) {
         this.clearSearch();
         if (this.multiple) {
           // Keep the search input clear for further typing
@@ -852,7 +999,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
 
       // Set focus after updating so the value is announced by screen readers
       this.updateComplete.then(() => {
-        if (this.multiple && this.search && this.open) {
+        if (this.multiple && this._isTypeable && this.open) {
           this.displayInput.value = '';
         }
         this.displayInput.focus({preventScroll: true});
@@ -891,8 +1038,11 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     // Check for duplicate values in menu items
     allOptions.forEach(option => values.push(option.value));
 
-    // Select only the options that match the new value
-    this.setSelectedOptions(allOptions.filter(el => value.includes(el.value)));
+    // In free-text mode, materialise any value with no matching option so it renders as a tag/value
+    this._materialiseFreeTextValues(value);
+
+    // Select only the options that match the new value (re-query in case options were materialised)
+    this.setSelectedOptions(this.getAllOptions().filter(el => value.includes(el.value)));
 
     // of check if an option has selected attribute set initially
     if (!this.valueHasChanged) {
@@ -920,6 +1070,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     event.stopImmediatePropagation();
 
     if (!this.disabled) {
+      // Deselecting drops the backing element for free-text values via selectionChanged's cleanup.
       this.toggleOptionSelection(option, false);
 
       // Emit after updating
@@ -976,7 +1127,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       option.tabIndex = 0;
       // When search is active and the display input has focus, don't steal focus to the option.
       // The user is typing in the search input and we only want to visually highlight the current option.
-      if (!(this.search && this.open && this.shadowRoot?.activeElement === this.displayInput)) {
+      if (!(this._isTypeable && this.open && this.shadowRoot?.activeElement === this.displayInput)) {
         option.focus();
       }
     }
@@ -1015,6 +1166,13 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
   private selectionChanged() {
     // Update selected options cache
     this.selectedOptions = this.getAllOptions().filter(el => el.selected);
+
+    // Free-text options exist only to anchor a selected value. Drop any that are no longer selected — e.g.
+    // when a single-select value is replaced or the selection is cleared, the previous custom entry should
+    // disappear entirely rather than linger as an orphaned option.
+    this.querySelectorAll<ZnOption>('[data-free-text]').forEach(option => {
+      if (!option.selected) option.remove();
+    });
 
     // In remote-search + multiple mode, track selected items so they persist across search result changes
     if (this._isRemoteSearch && this.multiple) {
@@ -1408,8 +1566,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       // Reset the current option
       this.setCurrentOption(null);
 
-      // When search is enabled, clear the display input to allow typing and show all options
-      if (this.search) {
+      // When typeable, clear the display input to allow typing and show all options
+      if (this._isTypeable) {
         this.clearSearch();
         this.displayInput.value = '';
         this.displayInput.readOnly = false;
@@ -1429,7 +1587,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       });
 
       // Focus the search input so the user can start typing immediately
-      if (this.search) {
+      if (this._isTypeable) {
         requestAnimationFrame(() => {
           this.displayInput.focus({preventScroll: true});
         });
@@ -1449,8 +1607,13 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       this.emit('zn-hide');
       this.removeOpenListeners();
 
-      // When search is enabled, restore the display label and clear the search
-      if (this.search) {
+      // When typeable, restore the display label and clear the search
+      if (this._isTypeable) {
+        // Commit any pending free-text before clearing it (blur/close-to-commit). Don't refocus —
+        // the dropdown is closing because focus left the control.
+        if (this.freeText && this._searchDisplayValue.trim()) {
+          this.commitFreeText(false);
+        }
         this.clearSearch();
         this.displayInput.readOnly = true;
         // In multiple mode, tags show the selection so keep the input empty
@@ -1647,7 +1810,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
               'select--medium': this.size === 'medium',
               'select--large': this.size === 'large',
               'select--has-input-prefix': this.inputPrefix,
-              'select--search': this.search
+              'select--search': this._isTypeable
             })}
             placement=${this.placement}
             strategy=${this.hoist ? 'fixed' : 'absolute'}
@@ -1671,20 +1834,20 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
                 part="display-input"
                 class="select__display-input"
                 type="text"
-                placeholder=${this._fetchLoading ? 'Loading...' : this._fetchError ? this._fetchError : (this.search && this.open ? (this.displayLabel || this.placeholder || 'Search...') : this.placeholder)}
+                placeholder=${this._fetchLoading ? 'Loading...' : this._fetchError ? this._fetchError : (this._isTypeable && this.open ? (this.displayLabel || this.placeholder || 'Search...') : this.placeholder)}
                 .disabled=${isDisabled}
-                .value=${isFetchDisabled ? '' : (this.search && this.open) ? this._searchDisplayValue : (this.search && this.multiple) ? '' : this.displayLabel}
+                .value=${isFetchDisabled ? '' : (this._isTypeable && this.open) ? this._searchDisplayValue : (this._isTypeable && this.multiple) ? '' : this.displayLabel}
                 autocomplete="off"
                 spellcheck="false"
                 autocapitalize="off"
-                ?readonly=${!(this.search && this.open)}
+                ?readonly=${!(this._isTypeable && this.open)}
                 aria-controls="listbox"
                 aria-expanded=${this.open ? 'true' : 'false'}
                 aria-haspopup="listbox"
                 aria-labelledby="label"
                 aria-disabled=${isDisabled ? 'true' : 'false'}
                 aria-describedby="help-text"
-                aria-autocomplete=${this.search ? 'list' : 'none'}
+                aria-autocomplete=${this._isTypeable ? 'list' : 'none'}
                 role="combobox"
                 tabindex="0"
                 @focus=${this.handleFocus}
@@ -1747,6 +1910,17 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
               tabindex="-1"
               @mouseup=${this.handleOptionClick}
               @slotchange=${this.handleDefaultSlotChange}>
+              ${this._freeTextAddValue !== null
+                ? html`
+                  <div
+                    part="add-option"
+                    class="select__add-option"
+                    role="option"
+                    aria-selected="false"
+                    @mousedown=${this.handleAddOptionMouseDown}>
+                    Add "${this._freeTextAddValue}"
+                  </div>`
+                : nothing}
               <slot></slot>
               ${this._renderSelectedRemoteItems()}
               ${this._fetchedOptions.map(item =>
@@ -1780,7 +1954,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
                       Type to search...
                     </div>`
                   : html`
-                    <div part="empty-state" class="select__empty-state" ?hidden=${!this._noResultsVisible}>
+                    <div part="empty-state" class="select__empty-state"
+                         ?hidden=${!this._noResultsVisible || this._freeTextAddValue !== null}>
                       No matching options
                     </div>`
               }

--- a/src/components/select/select.component.ts
+++ b/src/components/select/select.component.ts
@@ -120,6 +120,9 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
   /** @internal - whether the "no matching options" empty state is visible */
   @state() private _noResultsVisible = false;
 
+  /** @internal - whether the free-text "Add" row is the active keyboard-navigation target */
+  @state() private _addOptionActive = false;
+
   /** @internal */
   @state() private _fetchedOptions: ({ key: string; value: string; group?: undefined } | {
     group: string;
@@ -520,9 +523,10 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
         return;
       }
 
-      // Free-text: a highlighted real option wins; otherwise commit the typed value
+      // Free-text: commit when the Add row is the active target, or when no real option is highlighted
       if (this.freeText) {
-        const usableCurrent = this.currentOption && !this.currentOption.disabled && !this.currentOption.hidden;
+        const addActive = this._addOptionActive && this._freeTextAddValue !== null;
+        const usableCurrent = !addActive && this.currentOption && !this.currentOption.disabled && !this.currentOption.hidden;
         if (!usableCurrent && this.commitFreeText()) {
           return;
         }
@@ -566,12 +570,8 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
       return;
     }
 
-    // Navigate options
+    // Navigate options (and the free-text "Add" row, when shown)
     if (['ArrowUp', 'ArrowDown', 'Home', 'End'].includes(event.key)) {
-      const navOptions = this._isTypeable ? this.getVisibleOptions() : this.getAllOptions();
-      const currentIndex = navOptions.indexOf(this.currentOption);
-      let newIndex = Math.max(0, currentIndex);
-
       // Prevent scrolling
       event.preventDefault();
 
@@ -586,19 +586,39 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
         }
       }
 
+      const navOptions = this._isTypeable ? this.getVisibleOptions() : this.getAllOptions();
+      const hasAdd = this.freeText && this._freeTextAddValue !== null;
+
+      // The Add row, when shown, sits at the top of the listbox and is the first navigable target.
+      const ADD = 'add';
+      const targets: (ZnOption | typeof ADD)[] = hasAdd ? [ADD, ...navOptions] : [...navOptions];
+      if (targets.length === 0) return;
+
+      const currentTarget: ZnOption | typeof ADD | null =
+        this._addOptionActive && hasAdd ? ADD : (this.currentOption ?? null);
+      const currentIndex = currentTarget === null ? -1 : targets.indexOf(currentTarget);
+      let newIndex = Math.max(0, currentIndex);
+
       if (event.key === 'ArrowDown') {
         newIndex = currentIndex + 1;
-        if (newIndex > navOptions.length - 1) newIndex = 0;
+        if (newIndex > targets.length - 1) newIndex = 0;
       } else if (event.key === 'ArrowUp') {
         newIndex = currentIndex - 1;
-        if (newIndex < 0) newIndex = navOptions.length - 1;
+        if (newIndex < 0) newIndex = targets.length - 1;
       } else if (event.key === 'Home') {
         newIndex = 0;
       } else if (event.key === 'End') {
-        newIndex = navOptions.length - 1;
+        newIndex = targets.length - 1;
       }
 
-      this.setCurrentOption(navOptions[newIndex]);
+      const next = targets[newIndex];
+      if (next === ADD) {
+        this._addOptionActive = true;
+        this.setCurrentOption(null);
+      } else {
+        this._addOptionActive = false;
+        this.setCurrentOption(next);
+      }
     }
 
     // When typeable, let the input handle keystrokes natively (they go through handleSearchInput)
@@ -744,6 +764,9 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
   private handleSearchInput() {
     if (!this._isTypeable) return;
 
+    // A new keystroke resets the Add-row keyboard highlight
+    this._addOptionActive = false;
+
     this._searchDisplayValue = this.displayInput.value;
     this._searchQuery = this._searchDisplayValue.toLowerCase();
 
@@ -836,6 +859,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
     this._searchQuery = '';
     this._searchDisplayValue = '';
     this._noResultsVisible = false;
+    this._addOptionActive = false;
 
     // Cancel any pending remote search
     if (this._searchDebounceTimer !== null) {
@@ -1834,7 +1858,7 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
                 part="display-input"
                 class="select__display-input"
                 type="text"
-                placeholder=${this._fetchLoading ? 'Loading...' : this._fetchError ? this._fetchError : (this._isTypeable && this.open ? (this.displayLabel || this.placeholder || 'Search...') : this.placeholder)}
+                placeholder=${this._fetchLoading ? 'Loading...' : this._fetchError ? this._fetchError : (this._isTypeable && this.open ? (this.multiple ? (this.selectedOptions.length ? '' : (this.placeholder || 'Search...')) : (this.displayLabel || this.placeholder || 'Search...')) : this.placeholder)}
                 .disabled=${isDisabled}
                 .value=${isFetchDisabled ? '' : (this._isTypeable && this.open) ? this._searchDisplayValue : (this._isTypeable && this.multiple) ? '' : this.displayLabel}
                 autocomplete="off"
@@ -1914,9 +1938,12 @@ export default class ZnSelect extends ZincElement implements ZincFormControl {
                 ? html`
                   <div
                     part="add-option"
-                    class="select__add-option"
+                    class=${classMap({
+                      'select__add-option': true,
+                      'select__add-option--current': this._addOptionActive
+                    })}
                     role="option"
-                    aria-selected="false"
+                    aria-selected=${this._addOptionActive ? 'true' : 'false'}
                     @mousedown=${this.handleAddOptionMouseDown}>
                     Add "${this._freeTextAddValue}"
                   </div>`

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -448,7 +448,7 @@
   align-items: center;
   padding: var(--zn-spacing-x-small) var(--zn-spacing-small);
   color: var(--zn-input-color);
-  font-size: var(--zn-font-size-medium);
+  font-size: var(--zn-font-size-small);
   cursor: pointer;
 
   &:hover,

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -442,6 +442,20 @@
   }
 }
 
+/* Free-text "Add" row */
+.select__add-option {
+  display: flex;
+  align-items: center;
+  padding: var(--zn-spacing-x-small) var(--zn-spacing-small);
+  color: var(--zn-input-color);
+  font-size: var(--zn-font-size-medium);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--zn-color-primary-100);
+  }
+}
+
 /* Search mode */
 .select--search .select__combobox {
   cursor: text;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -451,7 +451,8 @@
   font-size: var(--zn-font-size-medium);
   cursor: pointer;
 
-  &:hover {
+  &:hover,
+  &.select__add-option--current {
     background-color: var(--zn-color-primary-100);
   }
 }

--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -176,4 +176,414 @@ describe('<zn-select>', () => {
     });
 
   });
+
+  describe('free-text', () => {
+    const type = (el: ZnSelect, text: string) => {
+      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      displayInput.value = text;
+      displayInput.dispatchEvent(new Event('input'));
+    };
+
+    const pressEnter = (el: ZnSelect) => {
+      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      displayInput.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      }));
+    };
+
+    it('commits typed text not in the list as the value on Enter', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.value).to.equal('kiwi');
+    });
+
+    it('adds typed values as tags in multiple mode, keeping the dropdown open', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text multiple></zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      type(el, 'mango');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.value).to.deep.equal(['kiwi', 'mango']);
+      expect(el.open).to.be.true;
+    });
+
+    it('selects the existing option instead of creating a duplicate on exact match', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'Apple'); // case-insensitive match of the existing label
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.value).to.equal('apple');
+      expect(el.querySelectorAll('zn-option').length).to.equal(1);
+      expect(el.querySelector('[data-free-text]')).to.be.null;
+    });
+
+    it('shows an Add row for non-matching text and commits it on click', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+
+      const addRow = el.shadowRoot!.querySelector<HTMLElement>('.select__add-option');
+      expect(addRow, 'Add row should be visible for non-matching text').to.exist;
+
+      addRow!.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, composed: true, cancelable: true}));
+      addRow!.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      expect(el.value).to.equal('kiwi');
+    });
+
+    it('commits the Add row on click without also selecting an option', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text multiple>
+          <zn-option value="apple">Apple</zn-option>
+          <zn-option value="banana">Banana</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      // "ap" filters to Apple (still visible) and offers Add "ap" at the top of the listbox
+      type(el, 'ap');
+      await el.updateComplete;
+
+      const addRow = el.shadowRoot!.querySelector<HTMLElement>('.select__add-option')!;
+      addRow.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, composed: true, cancelable: true}));
+      await el.updateComplete;
+
+      // The mouseup hits whatever now sits under the cursor. If committing on mousedown removed the Add
+      // row (the bug), the first option shifts up into that spot and would be wrongly selected on mouseup.
+      const underCursor = el.shadowRoot!.querySelector<HTMLElement>('.select__add-option')
+        ?? el.querySelector<HTMLElement>('zn-option');
+      underCursor!.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      // Only the typed value is committed — the first option ("apple") must not be selected too
+      expect(el.value).to.deep.equal(['ap']);
+    });
+
+    it('keeps the Add row text in sync as the user keeps typing', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'te');
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.select__add-option')!.textContent!.trim())
+        .to.equal('Add "te"');
+
+      // Continue typing without crossing the match/no-match boundary
+      type(el, 'testssdfs');
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.select__add-option')!.textContent!.trim())
+        .to.equal('Add "testssdfs"');
+    });
+
+    it('does not show the Add row when the text exactly matches an option', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'Apple');
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.select__add-option')).to.be.null;
+    });
+
+    it('commits pending typed text when the dropdown closes', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+
+      await el.hide();
+      await el.updateComplete;
+
+      expect(el.value).to.equal('kiwi');
+    });
+
+    it('removes the backing option from the DOM when a custom tag is removed', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text multiple></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(1);
+
+      const chip = el.shadowRoot!.querySelector('.select__tags zn-chip')!;
+      chip.dispatchEvent(new CustomEvent('zn-remove', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(0);
+      expect(el.value).to.deep.equal([]);
+    });
+
+    it('materialises an unmatched initial value as a custom option', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text value="custom-thing">
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+
+      expect(el.value).to.equal('custom-thing');
+      const created = el.querySelector('[data-free-text]');
+      expect(created, 'a backing option should be created').to.exist;
+      expect(created!.getAttribute('value')).to.equal('custom-thing');
+      expect(el.displayLabel).to.equal('custom-thing');
+    });
+
+    it('does not add a duplicate when the same custom value is committed twice', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text multiple></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.value).to.deep.equal(['kiwi']);
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(1);
+    });
+
+    it('enables an editable, filtering input on its own (without search)', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+          <zn-option value="banana">Banana</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      expect(displayInput.readOnly).to.be.false;
+
+      type(el, 'app');
+      await el.updateComplete;
+
+      const visible = [...el.querySelectorAll<ZnOption>('zn-option')].filter(o => !o.hidden);
+      expect(visible.map(o => o.value)).to.deep.equal(['apple']);
+    });
+
+    it('submits committed free-text values as form data', async () => {
+      const form = await fixture<HTMLFormElement>(html`
+        <form>
+          <zn-select name="fruits" free-text multiple></zn-select>
+        </form>
+      `);
+      const el = form.querySelector<ZnSelect>('zn-select')!;
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      type(el, 'mango');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      const formData = new FormData(form);
+      expect(formData.getAll('fruits')).to.deep.equal(['kiwi', 'mango']);
+    });
+
+    it('cancels uncommitted free-text on Escape instead of committing it', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+
+      const displayInput = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      displayInput.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      }));
+      await el.updateComplete;
+
+      expect(el.value).to.equal('');
+    });
+
+    it('removes a previous custom entry when a different option is selected (single)', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+      expect(el.value).to.equal('kiwi');
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(1);
+
+      // Reopen and pick a real option
+      await el.show();
+      await el.updateComplete;
+      const apple = el.querySelector<ZnOption>('zn-option[value="apple"]')!;
+      apple.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      expect(el.value).to.equal('apple');
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(0);
+    });
+
+    it('shows a committed custom option as a selected row in the listbox', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+
+      // Reopen the dropdown
+      await el.show();
+      await el.updateComplete;
+
+      const custom = el.querySelector<ZnOption>('[data-free-text]')!;
+      expect(custom, 'custom option should exist').to.exist;
+      expect(custom.hidden, 'custom option should be visible so it can be deselected').to.be.false;
+      expect(custom.selected, 'custom option should be selected').to.be.true;
+    });
+
+    it('removes a committed custom option when it is deselected from the dropdown', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text multiple></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+      expect(el.value).to.deep.equal(['kiwi']);
+
+      // Click the custom option's row in the listbox to deselect it
+      const custom = el.querySelector<ZnOption>('[data-free-text]')!;
+      custom.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      expect(el.value).to.deep.equal([]);
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(0);
+    });
+
+    it('can re-add a free-text value after it was removed', async () => {
+      const el = await fixture<ZnSelect>(html`<zn-select free-text multiple></zn-select>`);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      // Add "foo"
+      type(el, 'foo');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+      expect(el.value).to.deep.equal(['foo']);
+
+      // Remove it via the tag's remove button
+      const chip = el.shadowRoot!.querySelector('.select__tags zn-chip')!;
+      chip.dispatchEvent(new CustomEvent('zn-remove', {bubbles: true, composed: true}));
+      await el.updateComplete;
+      expect(el.value).to.deep.equal([]);
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(0);
+
+      // Add the same value again
+      type(el, 'foo');
+      await el.updateComplete;
+      pressEnter(el);
+      await el.updateComplete;
+      expect(el.value).to.deep.equal(['foo']);
+      expect(el.querySelectorAll('[data-free-text]').length).to.equal(1);
+    });
+  });
 });

--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -585,5 +585,55 @@ describe('<zn-select>', () => {
       expect(el.value).to.deep.equal(['foo']);
       expect(el.querySelectorAll('[data-free-text]').length).to.equal(1);
     });
+
+    it('does not put the "N selected" summary in the input placeholder in multiple mode', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text multiple>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      // Select an option — in multiple+search the dropdown stays open
+      const apple = el.querySelector<ZnOption>('zn-option[value="apple"]')!;
+      apple.dispatchEvent(new MouseEvent('mouseup', {bubbles: true, composed: true}));
+      await el.updateComplete;
+
+      const input = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      // The tags convey the selection; the input placeholder must not also show "1 option selected"
+      expect(input.placeholder).to.equal('');
+    });
+
+    it('lets keyboard navigation reach the Add row over a closer-matching option', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text>
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'app'); // matches Apple AND offers Add "app"
+      await el.updateComplete;
+
+      // ArrowDown highlights the Add row (it sits at the top of the list)
+      const input = el.shadowRoot!.querySelector<HTMLInputElement>('.select__display-input')!;
+      input.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+        composed: true,
+        cancelable: true
+      }));
+      await el.updateComplete;
+
+      // Enter commits the typed value, not the matching option
+      pressEnter(el);
+      await el.updateComplete;
+
+      expect(el.value).to.equal('app');
+    });
   });
 });

--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -635,5 +635,22 @@ describe('<zn-select>', () => {
 
       expect(el.value).to.equal('app');
     });
+
+    it('renders the Add row text at the small option font size', async () => {
+      const el = await fixture<ZnSelect>(html`
+        <zn-select free-text style="--zn-font-size-small: 11px; --zn-font-size-medium: 99px;">
+          <zn-option value="apple">Apple</zn-option>
+        </zn-select>
+      `);
+      await el.updateComplete;
+      await el.show();
+      await el.updateComplete;
+
+      type(el, 'kiwi');
+      await el.updateComplete;
+
+      const addRow = el.shadowRoot!.querySelector<HTMLElement>('.select__add-option')!;
+      expect(getComputedStyle(addRow).fontSize).to.equal('11px');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a `free-text` attribute to **`zn-select`** that lets users enter values that aren't in the options list, and exposes it through **`zn-inline-edit`**.

### `zn-select`
- New `free-text` attribute. It **implies** the editable, filtering `search` input — `<zn-select free-text>` is a typeable combobox that also accepts custom values.
- A typed value is committed via **Enter**, the **"Add …" row**, or **blur**; **Escape** cancels the pending entry.
- **Exact match** (label or value, case-insensitive) selects the existing option instead of creating a duplicate; values are **deduped**.
- A committed value is backed by a real, selected `<zn-option>` appended to the light DOM, so it flows through the existing **tag / value / form-submission** machinery and renders as a **deselectable row** in the dropdown. Deselecting a custom value removes it.
- Initial `value` / `defaultValue` entries with no matching option are **materialised on load**, so saved custom values round-trip.

### `zn-inline-edit`
- New `free-text` attribute, forwarded to the inner `zn-select`. Setting it **implies a select input** (no need for `input-type="select"`).
- Multi-select tags are now **removable (show the X) while editing**.

## Testing
- `zn-select`: 18 new tests (commit paths, single/multiple, exact-match, dedupe, live Add-row text, Escape-cancel, removal, **add → remove → re-add**, round-trip, click-without-stray-selection). 29 total.
- `zn-inline-edit`: 3 new tests (passthrough, implied select, removable-while-editing). 21 total.
- All green on Chromium + WebKit; `node scripts/build.js` passes (TypeScript + docs).

## Docs
Added "Free Text Entry" / "Free Text Select" sections to `select.md` and `inline-edit.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)