### PR TITLE
Add title tooltip and subText support to data-table cells

### DIFF
--- a/src/components/data-table/data-table.component.ts
+++ b/src/components/data-table/data-table.component.ts
@@ -36,6 +36,7 @@ const DEFAULT_PER_PAGE = 10;
 
 interface Cell {
   text: string;
+  subText?: string;
   column: string;
   color?: string;
   style?: string;
@@ -51,6 +52,7 @@ interface Cell {
   uri?: string;
   target?: string;
   copyable?: boolean;
+  title?: string;
 }
 
 interface Row {
@@ -123,7 +125,7 @@ const defaultTemplates = {
   dateTime: ((cell) => {
     const t = cell.text || '';
     return html`
-      <div class="table__collum--datetime">
+      <div class="table__collum--datetime" title="${ifDefined(cell.title)}">
         <span><strong>${t.slice(0, 10)}</strong></span>
         <zn-style size="s" muted>${t.slice(11)}</zn-style>
       </div>`
@@ -1013,7 +1015,7 @@ export default class ZnDataTable extends ZincElement {
     if(header?.cellTemplate !== undefined) {
       data = {...header.cellTemplate, ...data}
     }
-
+    
     let content: TemplateResult | ZincElement = html`${data.text}`;
 
     if (data.style || data.color) {
@@ -1039,55 +1041,25 @@ export default class ZnDataTable extends ZincElement {
           border="${isBorder || nothing}"
           center="${isCenter || nothing}"
           muted="${isMuted || nothing}"
-          color="${ifDefined(data.color)}">${content}
+          color="${ifDefined(data.color)}"
+          title="${ifDefined(data.title)}"
+        >${content}
         </zn-style>`;
     }
 
     if (data.uri) {
       content = html`
         <a href="${data.uri}"
+           title="${ifDefined(data.title)}"
            data-target="${ifDefined(data.target || nothing)}"
            gaid="${ifDefined(data.gaid || nothing)}">${content}</a>`;
     }
 
     if (data.chipColor) {
-      return html`
-        <zn-chip type="${data.chipColor}">${content}</zn-chip>`;
+      content = html`
+        <zn-chip type="${data.chipColor}" title="${ifDefined(data.title)}">${content}</zn-chip>`;
     }
 
-    if (data.hoverContent) {
-      const placement = data.hoverPlacement ?? 'top';
-
-      if (data.iconSrc) {
-        const src = data.iconSrc;
-        const color = data.iconColor;
-        const size = data.iconSize;
-        const tokens = (data.iconStyle ?? '').split(',').map(s => s.trim()).filter(Boolean);
-
-        return html`
-          ${content}
-          <zn-hover-container placement="${placement}" flip>
-            <zn-icon
-              src="${src}"
-              size="${ifDefined(size)}"
-              color="${ifDefined(color)}"
-              ${ref(el => {
-                if (!el) return;
-                tokens.forEach(t => el.setAttribute(t, ''));
-              })}
-            ></zn-icon>
-            <div slot="content">
-              ${unsafeHTML(data.hoverContent)}
-            </div>
-          </zn-hover-container>`;
-      }
-
-      return html`
-        <zn-hover-container placement="${placement}" flip>
-          <div slot="anchor">${content}</div>
-          ${unsafeHTML(data.hoverContent)}
-        </zn-hover-container>`;
-    }
 
     if (data.iconSrc) {
       const src = data.iconSrc;
@@ -1095,23 +1067,56 @@ export default class ZnDataTable extends ZincElement {
       const size = data.iconSize;
       const tokens = (data.iconStyle ?? '').split(',').map(s => s.trim()).filter(Boolean);
 
-      return html`
+      content = html`
         <zn-icon
           src="${src}"
           size="${ifDefined(size)}"
           color="${ifDefined(color)}"
           ${ref(el => {
-            if (!el) return;
-            tokens.forEach(t => el.setAttribute(t, ''));
-          })}
+        if (!el) return;
+        tokens.forEach(t => el.setAttribute(t, ''));
+      })}
+          title="${ifDefined(data.title)}"
         ></zn-icon> ${content}`;
     }
 
+    if (data.hoverContent) {
+      const placement = data.hoverPlacement ?? 'top';
+      if (data.iconSrc) {
+        content = html`
+          <zn-hover-container placement="${placement}" flip>
+            ${content}
+            <div slot="content">
+              ${unsafeHTML(data.hoverContent)}
+            </div>
+          </zn-hover-container>`;
+      } else {
+        content = html`
+          <zn-hover-container placement="${placement}" flip>
+            ${content}
+            <div slot="content">
+                ${unsafeHTML(data.hoverContent)}
+            </div>
+          </zn-hover-container>`;
+      }
+    }
+
     if (data.copyable) {
-      return html`
+      content = html`
         ${content}
         <zn-copy-button value="${data.text}"></zn-copy-button>`;
     }
+
+
+    if (data.subText) {
+      content = html`
+        <div>
+          <div>${content}</div>
+          <span class="table__cell--subtext">${data.subText}</span>
+        </div>
+      `
+    }
+
 
     return content;
 
@@ -1193,7 +1198,7 @@ export default class ZnDataTable extends ZincElement {
       return !header.secondary;
     });
     const header: HeaderConfig | undefined = filteredHeaders[index];
-    const headerKey: string = header?.key;
+    const headerKey: string | undefined = header?.key;
 
     return html`
       <td

--- a/src/components/data-table/data-table.scss
+++ b/src/components/data-table/data-table.scss
@@ -446,6 +446,6 @@ tbody tr.table__row--error td {
 }
 
 .table__cell--subtext{
-  font-size:0.9em;
-  opacity:0.6;
+  font-size: var(--zn-text-subheading-small-font-size);
+  line-height: var(--zn-text-subheading-small-line-height);
 }

--- a/src/components/data-table/data-table.scss
+++ b/src/components/data-table/data-table.scss
@@ -446,6 +446,5 @@ tbody tr.table__row--error td {
 }
 
 .table__cell--subtext{
-  font-size: var(--zn-text-subheading-small-font-size);
-  line-height: var(--zn-text-subheading-small-line-height);
+  @include wc.text-style(subheading-small);
 }

--- a/src/components/data-table/data-table.scss
+++ b/src/components/data-table/data-table.scss
@@ -444,3 +444,8 @@ tbody tr.table__row--error td {
   align-items: flex-end;
   gap:2px;
 }
+
+.table__cell--subtext{
+  font-size:0.9em;
+  opacity:0.6;
+}

--- a/src/components/data-table/data-table.test.ts
+++ b/src/components/data-table/data-table.test.ts
@@ -1,5 +1,6 @@
 import '../../../dist/zn.min.js';
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
+import { render } from 'lit';
 import type ZnDataTable from './data-table.component';
 
 describe('<zn-data-table>', () => {
@@ -53,5 +54,46 @@ describe('<zn-data-table>', () => {
     const el = await fixture<ZnDataTable>(html` <zn-data-table></zn-data-table> `);
     const templates = (el as unknown as {displayTemplates: Record<string, unknown>}).displayTemplates;
     expect(templates).to.be.an('object');
+  });
+
+  it('renders subText as muted secondary text', async () => {
+    const el = await fixture<ZnDataTable>(html` <zn-data-table></zn-data-table> `);
+    const container = document.createElement('div');
+    render(el.renderCell({text: 'Main', column: 'name', subText: 'Secondary'}), container);
+
+    const subtext = container.querySelector('.table__cell--subtext');
+    expect(subtext).to.exist;
+    expect(subtext?.textContent).to.contain('Secondary');
+    expect(container.textContent).to.contain('Main');
+  });
+
+  it('applies title as a tooltip on link cells', async () => {
+    const el = await fixture<ZnDataTable>(html` <zn-data-table></zn-data-table> `);
+    const container = document.createElement('div');
+    render(el.renderCell({text: 'Go', column: 'name', uri: 'https://example.com', title: 'Tip'}), container);
+
+    const link = container.querySelector('a');
+    expect(link).to.exist;
+    expect(link?.getAttribute('title')).to.equal('Tip');
+  });
+
+  it('applies title as a tooltip on styled cells', async () => {
+    const el = await fixture<ZnDataTable>(html` <zn-data-table></zn-data-table> `);
+    const container = document.createElement('div');
+    render(el.renderCell({text: 'Val', column: 'name', style: 'bold', title: 'Info'}), container);
+
+    const styled = container.querySelector('zn-style');
+    expect(styled).to.exist;
+    expect(styled?.getAttribute('title')).to.equal('Info');
+  });
+
+  it('omits the title attribute when no title is provided', async () => {
+    const el = await fixture<ZnDataTable>(html` <zn-data-table></zn-data-table> `);
+    const container = document.createElement('div');
+    render(el.renderCell({text: 'Plain', column: 'name', uri: 'https://example.com'}), container);
+
+    const link = container.querySelector('a');
+    expect(link).to.exist;
+    expect(link?.hasAttribute('title')).to.be.false;
   });
 });


### PR DESCRIPTION
## Summary

Adds two new per-cell options to `zn-data-table`:

- **`title`** — sets a native tooltip (`title` attribute) on the cell content. Applied across the datetime, `zn-style`, link (`<a>`), chip, and icon templates.
- **`subText`** — renders muted secondary text below the main cell content, styled via the new `.table__cell--subtext` class.

## Changes

- Extend the `Cell` interface with optional `title` and `subText` fields.
- Refactor `renderCell` to build up `content` progressively rather than returning early, so `title`, `subText`, `copyable`, and `hoverContent` can layer together.
- Reorder the `hoverContent` block to wrap the composed content (including any icon).
- Add `.table__cell--subtext` styling.

## Testing

Added 4 unit tests to `data-table.test.ts` (all passing on Chromium + Webkit):
- `subText` renders as muted secondary text
- `title` applies as a tooltip on link cells
- `title` applies as a tooltip on styled cells
- `title` attribute is omitted when no title is provided

> Note: `title` is only wired on the styled/link/chip/icon render paths — a plain text-only cell does not carry a tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)